### PR TITLE
fix(sportsbook): added null to outcomes in schema

### DIFF
--- a/pkg/validator/schemas/real-time-events/sportsbook.schema.json
+++ b/pkg/validator/schemas/real-time-events/sportsbook.schema.json
@@ -82,7 +82,10 @@
               ],
               "type": "object"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "sports_name": {
             "type": "string"


### PR DESCRIPTION
This pull request updates the schema definition in `sportsbook.schema.json` to allow greater flexibility in data validation by permitting `null` values for certain fields.

Schema updates:

* [`pkg/validator/schemas/real-time-events/sportsbook.schema.json`](diffhunk://#diff-a09ed1a216531c4eb1c0ed4402fcaa836728e708c96abf03eb1e25402bdcf95fL85-R88): Modified the `type` of a field from `"array"` to allow both `"array"` and `"null"`, enabling the field to accept null values in addition to arrays.