### PR TITLE
DEV-13749: 🤑 Add schema validation for is_free_money field

### DIFF
--- a/pkg/validator/schemas/real-time-events/bonus.schema.json
+++ b/pkg/validator/schemas/real-time-events/bonus.schema.json
@@ -106,6 +106,10 @@
     "skip_publishing": {
       "description": "Skip publishing the event",
       "type": "boolean"
+    },
+    "is_free_money": {
+      "description": "Sweepstakes partner is using free to play currency",
+      "type": "boolean"
     }
   },
   "required": [

--- a/pkg/validator/schemas/real-time-events/casino.schema.json
+++ b/pkg/validator/schemas/real-time-events/casino.schema.json
@@ -120,6 +120,10 @@
     "wager_amount": {
       "description": "Amount (either bet or win) if the round was played using real money",
       "type": "number"
+    },
+    "is_free_money": {
+      "description": "Sweepstakes partner is using free to play currency",
+      "type": "boolean"
     }
   },
   "required": [


### PR DESCRIPTION
# Description

This PR introduces schema validation to ensure that the `is_free_money` field (if it exists) is the correct data type (boolean) for Casino and Bonus events.

For now, the `is_free_money` field is not added to the list of required fields because we want to ensure that these changes are backwards compatible. In the future, we can make the field required once we're confident that all brands are using the updates within the `crm-integration-producer` which add a default value for the field when it is not explicitly specified within the request body.

[ClickUp Ticket](https://app.clickup.com/t/24429466/DEV-13749)