### PR TITLE
Add IT_PING to real-time event schema validation

### DIFF
--- a/pkg/validator/schemas/real-time-events/it_ping.schema.json
+++ b/pkg/validator/schemas/real-time-events/it_ping.schema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://www.fasttrack-solutions.com/en/resources/integration/real-time-data/it-ping",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Integration Testing Ping Event (IT_PING)",
+  "type": "object",
+  "properties": {
+    "origin": {
+      "description": "The origin of the event",
+      "type": "string",
+      "minLength": 1
+    },
+    "ping_id": {
+      "description": "Unique identifier for the ping",
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "description": "The timestamp of the event",
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_id": {
+      "description": "The ID of the user",
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": [
+    "origin",
+    "ping_id",
+    "timestamp",
+    "user_id"
+  ]
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -61,6 +61,7 @@ func getNotificationTypes() []string {
 		"poker_tournament_cash_out_v2",
 		"poker_cash_game_buy_in_v2",
 		"poker_cash_game_cash_out_v2",
+		"it_ping",
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `it_ping` to the list of recognized notification types in the schema validator
- Creates the corresponding JSON schema file for IT_PING events with the required fields: `ping_id`, `user_id`, `timestamp`, `origin`

## Problem
When `ENABLE_EVENT_SCHEMA_VALIDATION` is enabled on `crm-integration-consumer`, IT_PING messages are rejected with `"invalid payload type it_ping"` because the type is not in `getNotificationTypes()`. This error is fatal (`log.Fatalf`) and crashes the consumer pod. Since the message is not acked before the crash, RabbitMQ redelivers it to the next pod — creating a poison-pill loop that crashes all consumer replicas.

**Impact observed in production (eu2):**
- softgenius namespace: 8,090 errors since Feb 5 (redelivery loop)
- kirgo namespace: 3,197 errors since Feb 10
- sefiarray namespace: 2,283 errors starting Feb 12 (~760/hour and accelerating)

## Test plan
- [x] `go test ./pkg/validator/...` passes
- [ ] Verify consumer pods no longer crash on IT_PING messages after updating the dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)