### PR TITLE
feat: add user_migration_approve JSON schema

### DIFF
--- a/pkg/validator/schemas/real-time-events/user_migration_approve.schema.json
+++ b/pkg/validator/schemas/real-time-events/user_migration_approve.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://www.fasttrack-solutions.com/en/resources/integration/real-time-data/user-migration-approve",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "User Migration Approve Event (USER_MIGRATION_APPROVE)",
+  "type": "object",
+  "properties": {
+    "user_id": {
+      "description": "The unique id of the user",
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "description": "Timestamp in RFC3339 format",
+      "type": "string",
+      "format": "date-time"
+    },
+    "origin": {
+      "description": "The origin of the request",
+      "type": "string"
+    },
+    "skip_publishing": {
+      "description": "Flag to skip publishing",
+      "type": "boolean"
+    }
+  },
+  "required": ["user_id", "timestamp", "origin"]
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -57,6 +57,7 @@ func getNotificationTypes() []string {
 		"user_update_v2",
 		"user_tags",
 		"user_migration",
+		"user_migration_approve",
 		"poker_tournament_buy_in_v2",
 		"poker_tournament_cash_out_v2",
 		"poker_cash_game_buy_in_v2",


### PR DESCRIPTION
## Description

Adds the missing `user_migration_approve.schema.json` schema file and registers `user_migration_approve` in `getNotificationTypes()`.

The `crm-integration-consumer` was crashing on every `USER_MIGRATION_APPROVE` message with:
> `invalid payload type user_migration_approve`

The error originates in `pkg/validator/validate.go` — the validator lowercases the message type and looks it up in a `schemasMap`. Since neither the schema file nor the type registration ever existed, every message failed validation before reaching the handler.

The schema mirrors the existing `user_migration` schema but without `migration_reference` (which is not part of the approve payload), matching the `UserMigrationApproveRequest` struct in `crm-integration-api`.

Fixes <TICKET-NUMBER>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Existing test suite in `pkg/validator` passes with the new schema loaded.

- [x] `go test ./...` passes — schema loads correctly via embedded FS

Deployed and tested on AmbassadoriBet Staging

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules